### PR TITLE
Fix disappearing left-most maze tiles on level complete

### DIFF
--- a/Complete/Pacman/Makefile
+++ b/Complete/Pacman/Makefile
@@ -4,7 +4,7 @@ SRCDIR := Scripts
 PRG1 := $(OBJDIR)/main.prg
 PRG2 := $(OBJDIR)/pacman.prg
 D64 := $(OBJDIR)/pacman_FH.d64
-PAK := exomizer sfx sys -t 64
+PAK := exomizer sfx systrim
 
 # Commands
 MKPRG2 = $(PAK) -o $(PRG2) $(PRG1)

--- a/Complete/Pacman/Scripts/main.asm
+++ b/Complete/Pacman/Scripts/main.asm
@@ -1,7 +1,7 @@
-//exomizer sfx sys -t 64 -x "inc $d020" -o pacman_FH.prg main.prg 
+//exomizer sfx systrim -o pacman_FH.prg main.prg 
 
 .var sid = LoadSid("../Assets/sfx/pac2.sid")
-.var game = "Plus"
+.var game = "" //set to "Plus" for Pac-Man Plus pallet
 
 MAIN: {
 

--- a/Complete/Pacman/Scripts/system/map/map.asm
+++ b/Complete/Pacman/Scripts/system/map/map.asm
@@ -269,31 +269,14 @@
 		rts
 	}
 
-	ColourSides: {
-
-		lda #BLACK
-
-		.for(var i=0; i<25; i++) {
-			
-			sta VIC.COLOR_RAM + (i * 40) + 6
-			sta VIC.COLOR_RAM + (i * 40) + 34 
-
-		}
-		
-
-		rts
-	}
-
-
 	DisplayInitialScreen: {
 
 		
 		jsr UTILITY.ClearScreen
 
-		lda #7
+		lda #6
 		ldx #29
 		jsr UTILITY.BlockBorders
-	//	jsr ColourSides
 
 		lda GAME.KillScreen
 		beq NormalMap

--- a/Complete/Pacman/Scripts/system/state/complete.asm
+++ b/Complete/Pacman/Scripts/system/state/complete.asm
@@ -31,7 +31,7 @@ COMPLETE: {
 		sta Flashes
 		sta PelletsCleared
 
-		lda #7
+		lda #6
 		ldx #0
 		jsr UTILITY.BlockBorders
 


### PR DESCRIPTION
Hi Nick,

I was playing your C64 port of Pac-Man again tonight & noticed that the leftmost maze tiles disappear during the level end flashing animation, so I decided to fix it. Any chance of you making any more C64 games, mate?

Cheers,
Ralph


Before Fix 
---
![vice-screen-2025051500255051](https://github.com/user-attachments/assets/13110fba-f0a9-4044-a1c6-609dc3bf8c0c)

After Fix
---
![vice-screen-2025051500230632](https://github.com/user-attachments/assets/cc676bea-f25b-4d89-b5de-75378bb1f295)
